### PR TITLE
Revamp booking UI with theme toggle and smarter scheduling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,12 +3,18 @@
 @tailwind utilities;
 
 :root {
-  --background: #000000;
-  --foreground: #ffffff;
+  --background: #f9f9f9;
+  --foreground: #1f1f1f;
+}
+
+.dark {
+  --background: #1f1f1f;
+  --foreground: #f9f9f9;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: sans-serif;
+  transition: background 0.3s, color 0.3s;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,32 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { UserDetailsForm } from "@/components/UserDetailsForm";
 import { Calendar } from "@/components/Calendar";
 
 const services = [
-  "Mentorship",
-  "Consultancy",
-  "Business Training",
-  "Mass Coaching",
+  { name: "Community Impact Planning", duration: 360 },
+  { name: "Startup Advisory Session", duration: 60 },
+  { name: "Skills Development Workshop", duration: 180 },
+  { name: "Growth Strategy Consultation", duration: 60 },
 ];
 
 export default function Home() {
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+  useEffect(() => {
+    if (theme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [theme]);
+
   const [step, setStep] = useState("service"); // 'service', 'details', 'calendar', 'confirmed'
-  const [selectedService, setSelectedService] = useState("");
+  const [selectedService, setSelectedService] = useState<{ name: string; duration: number } | null>(null);
   const [userDetails, setUserDetails] = useState({ name: "", phone: "", email: "" });
   const [bookingDetails, setBookingDetails] = useState({ date: "", time: "" });
 
-  const handleServiceSelect = (service: string) => {
+  const handleServiceSelect = (service: { name: string; duration: number }) => {
     setSelectedService(service);
     setStep("details");
   };
@@ -31,57 +40,60 @@ export default function Home() {
     setBookingDetails(details);
 
     const bookingData = {
-      service: selectedService,
+      service: selectedService?.name,
+      duration: selectedService?.duration,
       user: userDetails,
       booking: details,
     };
 
     try {
-      const response = await fetch('/api/book', {
-        method: 'POST',
+      const response = await fetch("/api/book", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(bookingData),
       });
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.message || 'Something went wrong');
+        throw new Error(errorData.message || "Something went wrong");
       }
 
       setStep("confirmed");
-
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
+      const message = error instanceof Error ? error.message : "Unknown error";
       alert(`Booking failed: ${message}`);
-      // Optional: reset the state to allow user to try again
       setStep("calendar");
     }
   };
 
   const startOver = () => {
     setStep("service");
-    setSelectedService("");
+    setSelectedService(null);
     setUserDetails({ name: "", phone: "", email: "" });
     setBookingDetails({ date: "", time: "" });
   };
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-8">
-        <header className="flex flex-col items-center text-center mb-12">
-          <img
-            src="https://fathilananozi.com/storage/fathila-widget-pic-1.png"
-            alt="Fathila Nanozi"
-            width={100}
-            height={100}
-            className="rounded-full mb-4"
-          />
-        <h1 className="text-4xl font-bold text-white">Book Fathila</h1>
+    <main className="flex flex-col items-center justify-center min-h-screen p-8 transition-colors duration-300">
+      <button
+        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        className="self-end mb-4 p-2 rounded-full border border-brand-pink text-brand-pink hover:bg-brand-pink hover:text-white transition-colors"
+      >
+        {theme === "dark" ? "Light" : "Dark"} Mode
+      </button>
+      <header className="flex flex-col items-center text-center mb-12">
+        <img
+          src="https://fathilananozi.com/storage/fathila-widget-pic-1.png"
+          alt="Fathila Nanozi"
+          width={100}
+          height={100}
+          className="rounded-full mb-4"
+        />
+        <h1 className="text-4xl font-bold">Book Fathila</h1>
         {step === "service" && (
-          <p className="text-lg text-gray-300 mt-2">
-            Choose a service to get started
-          </p>
+          <p className="text-lg mt-2">Choose a service to get started</p>
         )}
       </header>
 
@@ -90,26 +102,35 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {services.map((service) => (
               <button
-                key={service}
+                key={service.name}
                 onClick={() => handleServiceSelect(service)}
-                className="w-full text-left p-4 bg-gray-800 rounded-lg hover:bg-brand-pink transition-colors duration-300"
+                className="w-full text-left p-4 rounded-lg border border-brand-pink bg-white dark:bg-neutral-900 hover:bg-brand-pink hover:text-white transition-colors"
               >
-                <h3 className="text-xl font-semibold text-white">{service}</h3>
+                <h3 className="text-xl font-semibold">{service.name}</h3>
               </button>
             ))}
           </div>
         )}
 
-        {step === "details" && <UserDetailsForm service={selectedService} onSubmit={handleDetailsSubmit} />}
+        {step === "details" && selectedService && (
+          <UserDetailsForm service={selectedService.name} onSubmit={handleDetailsSubmit} />
+        )}
 
-        {step === "calendar" && <Calendar service={selectedService} onBook={handleBooking} />}
+        {step === "calendar" && selectedService && (
+          <Calendar service={selectedService.name} duration={selectedService.duration} onBook={handleBooking} />
+        )}
 
-        {step === "confirmed" && (
+        {step === "confirmed" && selectedService && (
           <div className="text-center">
-            <h2 className="text-2xl font-bold text-green-400 mb-4">Booking Confirmed!</h2>
+            <h2 className="text-2xl font-bold text-green-500 mb-4">Booking Confirmed!</h2>
             <p className="text-lg">Thank you, {userDetails.name}.</p>
-            <p>Your {selectedService} session is booked for {bookingDetails.date} at {bookingDetails.time}.</p>
-            <button onClick={startOver} className="mt-6 p-3 bg-brand-pink text-white font-bold rounded-lg hover:bg-opacity-90">
+            <p>
+              Your {selectedService.name} session is booked for {bookingDetails.date} at {bookingDetails.time}.
+            </p>
+            <button
+              onClick={startOver}
+              className="mt-6 p-3 bg-brand-pink text-white font-bold rounded-lg hover:bg-opacity-90"
+            >
               Book Another Session
             </button>
           </div>

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -4,11 +4,14 @@ import { useState, useEffect } from "react";
 
 export const Calendar = ({
   service,
+  duration,
   onBook,
 }: {
   service: string;
+  duration: number;
   onBook: (bookingDetails: { date: string; time: string }) => void;
 }) => {
+  const today = new Date();
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
@@ -36,7 +39,10 @@ export const Calendar = ({
   const startDay = startOfMonth.getDay();
 
   const handlePrevMonth = () => {
-    setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1));
+    const prev = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1);
+    if (prev >= new Date(today.getFullYear(), today.getMonth(), 1)) {
+      setCurrentDate(prev);
+    }
   };
 
   const handleNextMonth = () => {
@@ -55,62 +61,110 @@ export const Calendar = ({
     return availableSlotsData[dateString] || [];
   };
 
-  const availableSlots = getAvailableSlotsForDate(selectedDate);
+  const filterSlots = (slots: string[]): string[] => {
+    const startMinutes = 5 * 60 + 30; // 5:30 AM
+    const endMinutes = 18 * 60; // 6:00 PM
+    return slots.filter((time) => {
+      const [h, m] = time.split(":").map(Number);
+      const minutes = h * 60 + m;
+      if (minutes < startMinutes) return false;
+      if (minutes + duration > endMinutes) return false;
+      return true;
+    });
+  };
+
+  const availableSlots = filterSlots(getAvailableSlotsForDate(selectedDate));
 
   return (
     <div className="w-full max-w-lg mx-auto">
       <h2 className="text-2xl font-bold text-center mb-6">
         Select a date and time for {service}
       </h2>
-      {isLoading ? <p className="text-center">Loading availability...</p> : (
-      <div className="bg-gray-800 p-4 rounded-lg">
-        <div className="flex justify-between items-center mb-4">
-          <button onClick={handlePrevMonth} className="p-2 rounded-full bg-gray-700 hover:bg-brand-pink">&lt;</button>
-          <h3 className="text-xl font-semibold">
-            {currentDate.toLocaleString("default", { month: "long", year: "numeric" })}
-          </h3>
-          <button onClick={handleNextMonth} className="p-2 rounded-full bg-gray-700 hover:bg-brand-pink">&gt;</button>
-        </div>
-        <div className="grid grid-cols-7 gap-2 text-center">
-          {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map(day => (
-            <div key={day} className="font-semibold text-sm">{day}</div>
-          ))}
-          {Array.from({ length: startDay }).map((_, i) => <div key={`empty-${i}`} />)}
-          {Array.from({ length: daysInMonth }).map((_, i) => {
-            const day = i + 1;
-            const date = new Date(currentDate.getFullYear(), currentDate.getMonth(), day);
-            const dateString = date.toISOString().split("T")[0];
-            const hasSlots = availableSlotsData[dateString]?.length > 0;
-            const isSelected = selectedDate?.toDateString() === date.toDateString();
-
-            return (
-              <button
-                key={day}
-                onClick={() => handleDateClick(day)}
-                disabled={!hasSlots}
-                className={`p-2 rounded-full ${isSelected ? "bg-brand-pink" : (hasSlots ? "bg-gray-700 hover:bg-brand-pink" : "text-gray-500")}`}
-              >
+      {isLoading ? (
+        <p className="text-center">Loading availability...</p>
+      ) : (
+        <div className="p-4 rounded-lg bg-white dark:bg-neutral-900">
+          <div className="flex justify-between items-center mb-4">
+            <button
+              onClick={handlePrevMonth}
+              className="p-2 rounded-full border border-brand-pink text-brand-pink hover:bg-brand-pink hover:text-white disabled:opacity-50"
+              disabled={currentDate.getFullYear() === today.getFullYear() && currentDate.getMonth() === today.getMonth()}
+            >
+              &lt;
+            </button>
+            <h3 className="text-xl font-semibold">
+              {currentDate.toLocaleString("default", { month: "long", year: "numeric" })}
+            </h3>
+            <button
+              onClick={handleNextMonth}
+              className="p-2 rounded-full border border-brand-pink text-brand-pink hover:bg-brand-pink hover:text-white"
+            >
+              &gt;
+            </button>
+          </div>
+          <div className="grid grid-cols-7 gap-2 text-center">
+            {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
+              <div key={day} className="font-semibold text-sm">
                 {day}
-              </button>
-            );
-          })}
+              </div>
+            ))}
+            {Array.from({ length: startDay }).map((_, i) => (
+              <div key={`empty-${i}`} />
+            ))}
+            {Array.from({ length: daysInMonth }).map((_, i) => {
+              const day = i + 1;
+              const date = new Date(currentDate.getFullYear(), currentDate.getMonth(), day);
+              const dateString = date.toISOString().split("T")[0];
+              const rawSlots = availableSlotsData[dateString] || [];
+              const hasSlots = filterSlots(rawSlots).length > 0;
+              const isSelected = selectedDate?.toDateString() === date.toDateString();
+              const isPast = date < new Date(today.getFullYear(), today.getMonth(), today.getDate());
+              const isSunday = date.getDay() === 0;
+
+              return (
+                <button
+                  key={day}
+                  onClick={() => handleDateClick(day)}
+                  disabled={!hasSlots || isPast || isSunday}
+                  className={`p-2 rounded-full ${
+                    isSelected
+                      ? "bg-brand-pink text-white"
+                      : hasSlots && !isPast && !isSunday
+                      ? "border border-brand-pink hover:bg-brand-pink hover:text-white"
+                      : "text-gray-400 cursor-not-allowed"
+                  }`}
+                >
+                  {day}
+                </button>
+              );
+            })}
+          </div>
         </div>
-      </div>
       )}
 
       {selectedDate && (
         <div className="mt-6">
-          <h3 className="text-lg font-semibold text-center">Available slots for {selectedDate.toLocaleDateString()}</h3>
+          <h3 className="text-lg font-semibold text-center">
+            Available slots for {selectedDate.toLocaleDateString()}
+          </h3>
           <div className="grid grid-cols-3 gap-2 mt-4">
-            {availableSlots.length > 0 ? availableSlots.map(time => (
-              <button
-                key={time}
-                onClick={() => setSelectedTime(time)}
-                className={`p-2 rounded-lg ${selectedTime === time ? "bg-brand-pink" : "bg-gray-700 hover:bg-brand-pink"}`}
-              >
-                {time}
-              </button>
-            )) : <p className="col-span-3 text-center text-gray-400">No available slots for this day.</p>}
+            {availableSlots.length > 0 ? (
+              availableSlots.map((time) => (
+                <button
+                  key={time}
+                  onClick={() => setSelectedTime(time)}
+                  className={`p-2 rounded-lg ${
+                    selectedTime === time
+                      ? "bg-brand-pink text-white"
+                      : "border border-brand-pink hover:bg-brand-pink hover:text-white"
+                  }`}
+                >
+                  {time}
+                </button>
+              ))
+            ) : (
+              <p className="col-span-3 text-center text-gray-500">No available slots for this day.</p>
+            )}
           </div>
         </div>
       )}
@@ -118,7 +172,7 @@ export const Calendar = ({
       {selectedTime && (
         <button
           onClick={() => onBook({ date: selectedDate!.toISOString().split("T")[0], time: selectedTime })}
-          className="w-full mt-6 p-3 bg-green-500 text-white font-bold rounded-lg hover:bg-opacity-90 transition-colors duration-300"
+          className="w-full mt-6 p-3 bg-brand-pink text-white font-bold rounded-lg hover:bg-opacity-90"
         >
           Book Now for {selectedTime}
         </button>

--- a/src/components/UserDetailsForm.tsx
+++ b/src/components/UserDetailsForm.tsx
@@ -29,7 +29,7 @@ export const UserDetailsForm = ({
       </h2>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="name" className="block text-sm font-medium text-gray-300">
+          <label htmlFor="name" className="block text-sm font-medium mb-1">
             Name
           </label>
           <input
@@ -37,12 +37,12 @@ export const UserDetailsForm = ({
             id="name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="mt-1 block w-full p-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm focus:ring-brand-pink focus:border-brand-pink sm:text-sm"
+            className="mt-1 block w-full p-2 rounded-md border border-brand-pink bg-white dark:bg-neutral-900 focus:ring-brand-pink focus:border-brand-pink sm:text-sm"
             required
           />
         </div>
         <div>
-          <label htmlFor="phone" className="block text-sm font-medium text-gray-300">
+          <label htmlFor="phone" className="block text-sm font-medium mb-1">
             Phone / WhatsApp Number
           </label>
           <input
@@ -50,12 +50,12 @@ export const UserDetailsForm = ({
             id="phone"
             value={phone}
             onChange={(e) => setPhone(e.target.value)}
-            className="mt-1 block w-full p-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm focus:ring-brand-pink focus:border-brand-pink sm:text-sm"
+            className="mt-1 block w-full p-2 rounded-md border border-brand-pink bg-white dark:bg-neutral-900 focus:ring-brand-pink focus:border-brand-pink sm:text-sm"
             required
           />
         </div>
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-300">
+          <label htmlFor="email" className="block text-sm font-medium mb-1">
             Email (Optional)
           </label>
           <input
@@ -63,7 +63,7 @@ export const UserDetailsForm = ({
             id="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 block w-full p-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm focus:ring-brand-pink focus:border-brand-pink sm:text-sm"
+            className="mt-1 block w-full p-2 rounded-md border border-brand-pink bg-white dark:bg-neutral-900 focus:ring-brand-pink focus:border-brand-pink sm:text-sm"
           />
         </div>
         <button

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -9,7 +10,7 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        'brand-pink': '#E52A7A',
+        "brand-pink": "#E52A7A",
       },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",


### PR DESCRIPTION
## Summary
- add class-based dark mode and global light theme variables
- redesign booking flow with modern service options and theme toggle
- enforce scheduling rules for Sundays, time windows, and session durations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c1d9e9cdd08333925bd1a13dc29f74