### PR TITLE
Prevent horizontal page overflow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,11 @@
 }
 
 @layer base {
+  html,
+  body {
+    max-width: 100vw;
+    overflow-x: hidden;
+  }
   body {
     font-family: var(--font-inter), sans-serif;
     color: #1f2937;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={inter.variable}>
-      <body className="antialiased min-h-screen flex items-center justify-center">
+      <body className="antialiased min-h-screen w-screen overflow-x-hidden flex items-center justify-center">
         <div className="w-full max-w-2xl p-4 mx-auto space-y-8">{children}</div>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Ensure root layout uses full viewport width and hides horizontal overflow to prevent sideways scrolling.
- Limit `html` and `body` to viewport width and hide horizontal overflow globally for all pages.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1fe008c9883338dad982e2f047bfa