### PR TITLE
feat: refine ui with windows-inspired styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,37 +56,45 @@
   body {
     font-family: var(--font-inter), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     color: #1f2937;
-    background: linear-gradient(to bottom right, #ffffff, #ffe4e6, #fce7f3);
+    /* Windows 11 inspired mica background with subtle brand tint */
+    background:
+      radial-gradient(at 0% 0%, rgba(229, 42, 122, 0.08), transparent 60%),
+      linear-gradient(to bottom right, #ffffff, #f1f5f9);
+    background-attachment: fixed;
     min-height: 100vh;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     transition: color var(--transition), background var(--transition);
   }
-  
+
   .dark body {
     color: #f9f9f9;
-    background: linear-gradient(to bottom right, #171717, #171717, #262626);
+    background:
+      radial-gradient(at 0% 0%, rgba(229, 42, 122, 0.15), transparent 60%),
+      linear-gradient(to bottom right, #171717, #262626);
   }
-  
+
   /* Enhanced scrollbar */
   ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: 8px;
+    height: 8px;
   }
-  
+
   ::-webkit-scrollbar-track {
     background: transparent;
   }
-  
+
   ::-webkit-scrollbar-thumb {
-    background: rgba(229, 42, 122, 0.3);
-    border-radius: 3px;
-    transition: background var(--transition-fast);
+    background-color: rgba(229, 42, 122, 0.4);
+    border-radius: 8px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+    transition: background-color var(--transition-fast);
   }
-  
+
   ::-webkit-scrollbar-thumb:hover {
-    background: rgba(229, 42, 122, 0.5);
+    background-color: rgba(229, 42, 122, 0.6);
   }
   
   /* Selection styling */
@@ -156,11 +164,11 @@
   /* Enhanced Card */
   .card {
     position: relative;
-    border-radius: 0.75rem;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    background: rgba(255, 255, 255, 0.6);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    border-radius: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
     box-shadow: var(--shadow);
     padding: 1.25rem;
     transition: all var(--transition);
@@ -191,8 +199,8 @@
   }
   
   .dark .card {
-    border-color: rgba(64, 64, 64, 0.4);
-    background: rgba(38, 38, 38, 0.6);
+    border-color: rgba(64, 64, 64, 0.5);
+    background: rgba(38, 38, 38, 0.65);
   }
   
   .dark .card::before {
@@ -212,7 +220,7 @@
     gap: 0.5rem;
     padding: 0.75rem 1.25rem;
     font-weight: 600;
-    border-radius: 0.5rem;
+    border-radius: 0.75rem;
     background: linear-gradient(135deg, #E52A7A, #ec4899);
     color: #ffffff;
     box-shadow: var(--shadow);
@@ -260,7 +268,7 @@
   .btn-slot {
     position: relative;
     padding: 0.5rem 0.75rem;
-    border-radius: 0.375rem;
+    border-radius: 0.5rem;
     border: 1px solid rgba(229, 42, 122, 0.4);
     background: rgba(255, 255, 255, 0.6);
     backdrop-filter: blur(12px);
@@ -336,11 +344,11 @@
     position: relative;
     width: 100%;
     height: 2.75rem;
-    border-radius: 0.375rem;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    background: rgba(255, 255, 255, 0.6);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    border-radius: 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
     font-size: 0.875rem;
     padding: 0 0.75rem;
     transition: all var(--transition);
@@ -370,8 +378,8 @@
   }
   
   .dark .input-primary {
-    border-color: rgba(64, 64, 64, 0.5);
-    background: rgba(38, 38, 38, 0.6);
+    border-color: rgba(64, 64, 64, 0.6);
+    background: rgba(38, 38, 38, 0.65);
   }
   
   .dark .input-primary:hover {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,8 +19,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={inter.variable}>
-      <body className="antialiased min-h-screen w-screen overflow-x-hidden flex items-center justify-center">
-        <div className="w-full max-w-2xl p-4 mx-auto space-y-8">{children}</div>
+      <body className="antialiased min-h-screen w-screen overflow-x-hidden flex items-center justify-center bg-[var(--background)] text-[var(--foreground)]">
+        <div className="w-full max-w-2xl p-6 mx-auto space-y-8 rounded-3xl border border-white/40 bg-white/70 shadow-xl backdrop-blur-2xl dark:bg-neutral-900/60 dark:border-neutral-700/40 transition-colors">
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,10 +96,10 @@ export default function Home() {
   };
 
   return (
-    <main className="space-y-10">
+    <main className="space-y-10 animate-fade-in">
       <button
         onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-        className="ml-auto mb-4 p-2 rounded-full border border-brand-pink text-brand-pink hover:bg-brand-pink hover:text-white transition-colors"
+        className="ml-auto mb-4 p-2 rounded-xl border border-white/40 bg-white/60 text-brand-pink shadow-sm backdrop-blur hover:bg-white/80 hover:shadow transition-colors dark:border-neutral-700/60 dark:bg-neutral-800/60 dark:hover:bg-neutral-800/80"
         aria-label="Toggle Theme"
       >
         {theme === "dark" ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
@@ -110,14 +110,14 @@ export default function Home() {
           alt="Fathila Nanozi"
           width={100}
           height={100}
-          className="rounded-full"
+          className="rounded-full shadow-lg ring-1 ring-white/50 dark:ring-neutral-700/50"
         />
         <h1 className="text-3xl font-bold">Book Fathila</h1>
         {step === "service" && <p className="text-lg">Choose a service to get started</p>}
       </header>
 
       {step !== "confirmed" && (
-        <div className="max-w-md mx-auto h-2 bg-white/40 dark:bg-neutral-700 rounded-full overflow-hidden">
+        <div className="max-w-md mx-auto h-2 bg-white/50 dark:bg-neutral-700 rounded-full overflow-hidden shadow-inner">
           <div
             className="h-full bg-brand-pink transition-all"
             style={{
@@ -140,7 +140,7 @@ export default function Home() {
             <button
               key={service.name}
               onClick={() => handleServiceSelect(service)}
-              className="card flex flex-col items-start gap-3 p-6 text-left cursor-pointer transition-transform hover:-translate-y-1 hover:shadow-2xl"
+              className="card flex flex-col items-start gap-3 p-6 text-left cursor-pointer transition-transform hover:-translate-y-1 hover:shadow-2xl focus-visible:ring-2 focus-visible:ring-brand-pink/40"
             >
               <div className="flex items-center gap-2">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-pink text-white text-xs font-bold">

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -77,7 +77,7 @@ export const Calendar = ({
   const availableSlots = filterSlots(getAvailableSlotsForDate(selectedDate));
 
   return (
-    <div className="w-full max-w-lg mx-auto space-y-6">
+    <div className="w-full max-w-lg mx-auto space-y-6 animate-fade-in">
       <h2 className="text-2xl font-bold text-center">Select a date and time for {service}</h2>
       {isLoading ? (
         <p className="text-center">Loading availability...</p>
@@ -86,7 +86,7 @@ export const Calendar = ({
           <div className="flex justify-between items-center">
             <button
               onClick={handlePrevMonth}
-              className="p-2 rounded-full border border-brand-pink text-brand-pink hover:bg-brand-pink hover:text-white disabled:opacity-50"
+              className="p-2 rounded-lg border border-brand-pink/40 text-brand-pink hover:bg-brand-pink/10 hover:border-brand-pink/60 disabled:opacity-50"
               disabled={currentDate.getFullYear() === today.getFullYear() && currentDate.getMonth() === today.getMonth()}
             >
               <ChevronLeft className="w-4 h-4" />
@@ -96,7 +96,7 @@ export const Calendar = ({
             </h3>
             <button
               onClick={handleNextMonth}
-              className="p-2 rounded-full border border-brand-pink text-brand-pink hover:bg-brand-pink hover:text-white"
+              className="p-2 rounded-lg border border-brand-pink/40 text-brand-pink hover:bg-brand-pink/10 hover:border-brand-pink/60"
             >
               <ChevronRight className="w-4 h-4" />
             </button>
@@ -126,11 +126,11 @@ export const Calendar = ({
                   key={day}
                   onClick={() => handleDateClick(day)}
                   disabled={!hasSlots || isPast || isSunday}
-                  className={`w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center rounded-md transition-all ${
+                  className={`w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center rounded-lg transition-all ${
                     isSelected
                       ? "bg-brand-pink text-white"
                       : hasSlots && !isPast && !isSunday
-                      ? "border border-brand-pink/40 bg-white/60 dark:bg-neutral-800/60 backdrop-blur hover:bg-brand-pink hover:text-white"
+                      ? "border border-brand-pink/40 bg-white/60 dark:bg-neutral-800/60 backdrop-blur hover:bg-brand-pink hover:text-white hover:scale-105"
                       : "text-gray-400 cursor-not-allowed"
                   } ${isToday ? "ring-2 ring-brand-pink" : ""}`}
                 >

--- a/src/components/UserDetailsForm.tsx
+++ b/src/components/UserDetailsForm.tsx
@@ -20,55 +20,55 @@ export const UserDetailsForm = ({
     }
   };
   return (
-    <div className="w-full max-w-md mx-auto card">
+    <div className="w-full max-w-md mx-auto card animate-slide-up">
       <h2 className="text-2xl font-bold text-center mb-6">
         Enter your details for {service}
       </h2>
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div>
+        <div className="space-y-2">
           <label htmlFor="name" className="block text-sm font-medium mb-1">
             Name
           </label>
-          <div className="relative">
-            <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand-pink" />
+          <div className="relative group">
+            <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand-pink/70 transition-colors group-focus-within:text-brand-pink" />
             <input
               type="text"
               id="name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="input-primary pl-9"
+              className="input-primary pl-9 group-hover:border-brand-pink/40"
               required
             />
           </div>
         </div>
-        <div>
+        <div className="space-y-2">
           <label htmlFor="phone" className="block text-sm font-medium mb-1">
             Phone / WhatsApp Number
           </label>
-          <div className="relative">
-            <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand-pink" />
+          <div className="relative group">
+            <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand-pink/70 transition-colors group-focus-within:text-brand-pink" />
             <input
               type="tel"
               id="phone"
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
-              className="input-primary pl-9"
+              className="input-primary pl-9 group-hover:border-brand-pink/40"
               required
             />
           </div>
         </div>
-        <div>
+        <div className="space-y-2">
           <label htmlFor="email" className="block text-sm font-medium mb-1">
             Email (Optional)
           </label>
-          <div className="relative">
-            <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand-pink" />
+          <div className="relative group">
+            <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-brand-pink/70 transition-colors group-focus-within:text-brand-pink" />
             <input
               type="email"
               id="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="input-primary pl-9"
+              className="input-primary pl-9 group-hover:border-brand-pink/40"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- polish global styles with Windows 11-esque background, scrollbars and widgets
- wrap app layout in glass panel container for a fluent look
- refine booking form and calendar interactions with accent-focused hover effects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c26361286c83339d057bc7fb9ed7b9