### PR TITLE
Add attendee sizing and meeting preferences

### DIFF
--- a/src/app/api/book/route.ts
+++ b/src/app/api/book/route.ts
@@ -44,20 +44,26 @@ export async function POST(request: Request) {
       );
     }
 
-      // Save booking
-      const { data: bookingRow, error: insertError } = await supabase
-        .from('bookings')
-        .insert({
+    // Save booking
+    const { data: bookingRow, error: insertError } = await supabase
+      .from('bookings')
+      .insert({
         service: newBooking.service,
         user_name: newBooking.user?.name,
         user_phone: newBooking.user?.phone,
         user_email: newBooking.user?.email,
+        attendees: newBooking.meeting?.attendees,
+        meeting_type: newBooking.meeting?.meetingType,
+        location_option: newBooking.meeting?.locationOption,
+        address: newBooking.meeting?.address,
+        district: newBooking.meeting?.district,
+        country: newBooking.meeting?.country,
         date,
         time,
         status: 'booked',
-        })
-        .select('id')
-        .single();
+      })
+      .select('id')
+      .single();
 
       if (insertError) throw insertError;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,9 +12,9 @@
 }
 
 .dark {
-  --background: #000080;
+  --background: #1a1a1a;
   --foreground: #f3f3f3;
-  --surface: rgba(0, 0, 80, 0.65);
+  --surface: rgba(26, 26, 26, 0.65);
   --surface-border: rgba(255, 255, 255, 0.08);
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,21 +3,19 @@
 import { useState, useEffect } from "react";
 import { UserDetailsForm } from "@/components/UserDetailsForm";
 import { Calendar } from "@/components/Calendar";
-import {
-  Sun,
-  Moon,
-  Sparkles,
-  GraduationCap,
-  BarChart3,
-  Briefcase,
-  CheckCircle,
-} from "lucide-react";
+import { Sun, Moon, CheckCircle } from "lucide-react";
+import { AttendeeForm } from "@/components/AttendeeForm";
+import { MeetingTypeForm } from "@/components/MeetingTypeForm";
+import { LocationForm } from "@/components/LocationForm";
 
 const services = [
-  { name: "Community Impact Planning", duration: 360, icon: Sparkles },
-  { name: "Startup Advisory Session", duration: 60, icon: Briefcase },
-  { name: "Skills Development Workshop", duration: 180, icon: GraduationCap },
-  { name: "Growth Strategy Consultation", duration: 60, icon: BarChart3 },
+  {
+    name: "Business Formalization (e.g., Registration, Certification, TIN Registration, etc.)",
+    duration: 60,
+  },
+  { name: "Business Start-up Reviews & Consultation", duration: 60 },
+  { name: "Business Training & Workshop Facilitation", duration: 180 },
+  { name: "Community Development Initiatives", duration: 360 },
 ];
 
 export default function Home() {
@@ -41,29 +39,69 @@ export default function Home() {
 
   const [step, setStep] = useState("service");
   const [selectedService, setSelectedService] = useState<{ name: string; duration: number } | null>(null);
-    const [userDetails, setUserDetails] = useState({ name: "", phone: "", email: "", note: "", reminder: false });
+  const [meetingInfo, setMeetingInfo] = useState({
+    attendees: "",
+    meetingType: "",
+    locationOption: "",
+    address: "",
+    district: "",
+    country: "",
+  });
+  const [userDetails, setUserDetails] = useState({ name: "", phone: "", email: "", note: "", reminder: false });
   const [bookingDetails, setBookingDetails] = useState({ date: "", time: "" });
 
   const handleServiceSelect = (service: { name: string; duration: number }) => {
     setSelectedService(service);
+    setStep("attendees");
+  };
+
+  const handleAttendeeSubmit = (size: string) => {
+    setMeetingInfo((prev) => ({ ...prev, attendees: size }));
+    setStep("meeting-type");
+  };
+
+  const handleMeetingType = (type: "Physical" | "Online") => {
+    if (type === "Physical") {
+      setMeetingInfo((prev) => ({ ...prev, meetingType: type }));
+      setStep("location");
+    } else {
+      setMeetingInfo((prev) => ({ ...prev, meetingType: type, locationOption: "online" }));
+      setStep("online-info");
+    }
+  };
+
+  const handleLocationSubmit = (info: {
+    locationOption: string;
+    address: string;
+    district: string;
+    country: string;
+  }) => {
+    setMeetingInfo((prev) => ({ ...prev, ...info }));
     setStep("details");
   };
 
-    const handleDetailsSubmit = (details: { name: string; phone: string; email: string; note: string; reminder: boolean }) => {
-      setUserDetails(details);
-      setStep("calendar");
-    };
+  const handleDetailsSubmit = (details: {
+    name: string;
+    phone: string;
+    email: string;
+    note: string;
+    reminder: boolean;
+  }) => {
+    setUserDetails(details);
+    setStep("calendar");
+  };
 
   const handleBooking = async (details: { date: string; time: string }) => {
     setBookingDetails(details);
     const bookingData = {
       service: selectedService?.name,
       duration: selectedService?.duration,
-        user: { name: userDetails.name, phone: userDetails.phone, email: userDetails.email },
-        note: userDetails.note,
-        reminder: userDetails.reminder,
-        booking: details,
-      };
+      meeting: meetingInfo,
+      user: { name: userDetails.name, phone: userDetails.phone, email: userDetails.email },
+      note: userDetails.note,
+      reminder: userDetails.reminder,
+      booking: details,
+    };
     try {
       const response = await fetch("/api/book", {
         method: "POST",
@@ -85,7 +123,15 @@ export default function Home() {
   const startOver = () => {
     setStep("service");
     setSelectedService(null);
-      setUserDetails({ name: "", phone: "", email: "", note: "", reminder: false });
+    setMeetingInfo({
+      attendees: "",
+      meetingType: "",
+      locationOption: "",
+      address: "",
+      district: "",
+      country: "",
+    });
+    setUserDetails({ name: "", phone: "", email: "", note: "", reminder: false });
     setBookingDetails({ date: "", time: "" });
   };
 
@@ -94,7 +140,7 @@ export default function Home() {
       <button
         onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
         aria-label="Toggle Theme"
-          className="ml-auto mb-4 flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--surface-border)] bg-[var(--surface)] text-brand-pink shadow hover:bg-white/80 dark:hover:bg-neutral-700"
+        className="ml-auto mb-4 flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--surface-border)] bg-[var(--surface)] text-brand-pink shadow hover:bg-white/80 dark:hover:bg-neutral-700"
       >
         {theme === "dark" ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
       </button>
@@ -118,11 +164,17 @@ export default function Home() {
             style={{
               width:
                 step === "service"
-                  ? "25%"
+                  ? "14%"
+                  : step === "attendees"
+                  ? "28%"
+                  : step === "meeting-type"
+                  ? "42%"
+                  : step === "location" || step === "online-info"
+                  ? "56%"
                   : step === "details"
-                  ? "50%"
+                  ? "70%"
                   : step === "calendar"
-                  ? "75%"
+                  ? "85%"
                   : "100%",
             }}
           />
@@ -135,13 +187,13 @@ export default function Home() {
             <button
               key={service.name}
               onClick={() => handleServiceSelect(service)}
-                className="surface flex flex-col items-start gap-3 text-left hover:border-brand-pink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink"
+              className={`flex flex-col items-start gap-3 text-left p-4 rounded-lg border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink transition-colors $
+{theme === "dark" ? "bg-white text-black border-gray-300 hover:bg-gray-100" : "bg-gray-800 text-white border-gray-700 hover:bg-gray-700"}`}
             >
               <div className="flex items-center gap-2">
-                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-pink text-white text-xs font-bold">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-pink text-white text-xs font-bold">
                   {idx + 1}
                 </span>
-                  <service.icon className="w-5 h-5 text-brand-pink" />
               </div>
               <span className="text-sm font-medium">{service.name}</span>
             </button>
@@ -149,9 +201,22 @@ export default function Home() {
         </div>
       )}
 
-      {step === "details" && selectedService && (
-        <UserDetailsForm service={selectedService.name} onSubmit={handleDetailsSubmit} />
+      {step === "attendees" && <AttendeeForm onSubmit={handleAttendeeSubmit} />}
+
+      {step === "meeting-type" && <MeetingTypeForm onSubmit={handleMeetingType} />}
+
+      {step === "location" && <LocationForm onSubmit={handleLocationSubmit} />}
+
+      {step === "online-info" && (
+        <div className="surface max-w-md mx-auto space-y-4">
+          <p>If approved, the meeting will be hosted on my Zoom and might be recorded for record purposes.</p>
+          <button className="btn-accent w-full" onClick={() => setStep("details")}>
+            Continue
+          </button>
+        </div>
       )}
+
+      {step === "details" && selectedService && <UserDetailsForm service={selectedService.name} onSubmit={handleDetailsSubmit} />}
 
       {step === "calendar" && selectedService && (
         <Calendar service={selectedService.name} duration={selectedService.duration} onBook={handleBooking} />
@@ -165,6 +230,14 @@ export default function Home() {
           <p>
             Your {selectedService.name} session is booked for {bookingDetails.date} at {bookingDetails.time}.
           </p>
+          {meetingInfo.meetingType && <p>Meeting type: {meetingInfo.meetingType}</p>}
+          {meetingInfo.attendees && <p>Attendees: {meetingInfo.attendees}</p>}
+          {meetingInfo.locationOption === "other" && (
+            <p>
+              Location: {meetingInfo.address}, {meetingInfo.district}, {meetingInfo.country}
+            </p>
+          )}
+          {meetingInfo.locationOption === "office" && <p>Location: Kigobe Rd, Ntinda, Kampala</p>}
           {userDetails.note && <p className="italic">Note: {userDetails.note}</p>}
           {userDetails.reminder && <p>A reminder will be sent 24 hours before.</p>}
           <button onClick={startOver} className="btn-accent mt-2">

--- a/src/components/AttendeeForm.tsx
+++ b/src/components/AttendeeForm.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+interface Props {
+  onSubmit: (size: string) => void;
+}
+
+export function AttendeeForm({ onSubmit }: Props) {
+  const [size, setSize] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!size) return;
+    onSubmit(size);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="surface max-w-md mx-auto space-y-4">
+      <label className="block">
+        <span className="block mb-2 font-medium">Size of Attendees</span>
+        <select
+          value={size}
+          onChange={(e) => setSize(e.target.value)}
+          required
+          className="input-field"
+        >
+          <option value="" disabled>
+            Choose...
+          </option>
+          <option>Just Me</option>
+          <option>2 - 5 People</option>
+          <option>6 - 25 People</option>
+          <option>26+ People</option>
+        </select>
+      </label>
+      <button type="submit" className="btn-accent w-full">
+        Next
+      </button>
+    </form>
+  );
+}

--- a/src/components/LocationForm.tsx
+++ b/src/components/LocationForm.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+
+interface Props {
+  onSubmit: (info: {
+    locationOption: string;
+    address: string;
+    district: string;
+    country: string;
+  }) => void;
+}
+
+export function LocationForm({ onSubmit }: Props) {
+  const [choice, setChoice] = useState<"office" | "other" | "">("");
+  const [address, setAddress] = useState("");
+  const [district, setDistrict] = useState("");
+  const [country, setCountry] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (choice === "office") {
+      onSubmit({
+        locationOption: "office",
+        address: "Kigobe Rd, Ntinda, Kampala",
+        district: "",
+        country: "Uganda",
+      });
+    } else {
+      onSubmit({
+        locationOption: "other",
+        address,
+        district,
+        country,
+      });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="surface max-w-md mx-auto space-y-4">
+      <p className="font-medium">Where would you like to meet?</p>
+      <div className="flex flex-col gap-2">
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="loc"
+            value="office"
+            checked={choice === "office"}
+            onChange={() => setChoice("office")}
+            required
+          />
+          <span>My office - Kigobe Rd, Ntinda, Kampala</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name="loc"
+            value="other"
+            checked={choice === "other"}
+            onChange={() => setChoice("other")}
+          />
+          <span>Meeting point of your choice</span>
+        </label>
+      </div>
+      {choice === "other" && (
+        <div className="space-y-2">
+          <p className="text-sm italic">
+            Note: At the moment you are unable to meet persons outside of Uganda physically.
+          </p>
+          <input
+            className="input-field"
+            placeholder="Address"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            required
+          />
+          <input
+            className="input-field"
+            placeholder="District"
+            value={district}
+            onChange={(e) => setDistrict(e.target.value)}
+            required
+          />
+          <input
+            className="input-field"
+            placeholder="Country"
+            value={country}
+            onChange={(e) => setCountry(e.target.value)}
+            required
+          />
+        </div>
+      )}
+      <button type="submit" className="btn-accent w-full">
+        Next
+      </button>
+    </form>
+  );
+}

--- a/src/components/MeetingTypeForm.tsx
+++ b/src/components/MeetingTypeForm.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  onSubmit: (type: "Physical" | "Online") => void;
+}
+
+export function MeetingTypeForm({ onSubmit }: Props) {
+  return (
+    <div className="surface max-w-md mx-auto space-y-4">
+      <p className="font-medium">Do you prefer a physical or online meeting?</p>
+      <div className="flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={() => onSubmit("Physical")}
+          className="slot-btn"
+        >
+          Physical
+        </button>
+        <button
+          type="button"
+          onClick={() => onSubmit("Online")}
+          className="slot-btn"
+        >
+          Online
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/supabase/meeting_preferences.sql
+++ b/supabase/meeting_preferences.sql
@@ -1,0 +1,7 @@
+alter table bookings
+  add column attendees text,
+  add column meeting_type text,
+  add column location_option text,
+  add column address text,
+  add column district text,
+  add column country text;


### PR DESCRIPTION
## Summary
- replace services with four business-oriented options and remove icons
- capture attendee size, meeting type, and location details with new forms
- adjust dark theme color and brighten service buttons in dark mode

## Testing
- ✅ `npm run lint`
- ✅ `SUPABASE_URL=http://example.com SUPABASE_SERVICE_ROLE_KEY=key npm run build`
- ⚠️ `npm test` (missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c2953cb49c833383afd323a46a7fea