### PR TITLE
Add step indicator and back navigation to booking flow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Sun, Moon, CheckCircle } from "lucide-react";
 import { AttendeeForm } from "@/components/AttendeeForm";
 import { MeetingTypeForm } from "@/components/MeetingTypeForm";
 import { LocationForm } from "@/components/LocationForm";
+import { StepIndicator } from "@/components/StepIndicator";
 
 const services = [
   {
@@ -135,6 +136,30 @@ export default function Home() {
     setBookingDetails({ date: "", time: "" });
   };
 
+  const currentStepNumber =
+    step === "service"
+      ? 1
+      : step === "attendees"
+      ? 2
+      : step === "meeting-type" || step === "location" || step === "online-info"
+      ? 3
+      : step === "details"
+      ? 4
+      : 5;
+
+  const stepTitle =
+    step === "service"
+      ? "Select a Service"
+      : step === "attendees"
+      ? "How many people will attend?"
+      : step === "meeting-type" || step === "location" || step === "online-info"
+      ? "Meeting Type"
+      : step === "details"
+      ? "Contact Details"
+      : step === "calendar"
+      ? "Select Date & Time"
+      : "";
+
   return (
     <main className="space-y-10 animate-fade-in">
       <button
@@ -154,30 +179,13 @@ export default function Home() {
           className="rounded-full shadow ring-1 ring-[var(--surface-border)]"
         />
         <h1 className="text-3xl font-bold">Book Fathila</h1>
-        {step === "service" && <p className="text-lg">Choose a service to get started</p>}
+        <p className="text-sm text-gray-500">Professional Business Advisory & Consulting Services</p>
       </header>
-
       {step !== "confirmed" && (
-        <div className="max-w-md mx-auto h-2 bg-[var(--surface)] rounded-full overflow-hidden">
-          <div
-            className="h-full bg-brand-pink transition-all"
-            style={{
-              width:
-                step === "service"
-                  ? "14%"
-                  : step === "attendees"
-                  ? "28%"
-                  : step === "meeting-type"
-                  ? "42%"
-                  : step === "location" || step === "online-info"
-                  ? "56%"
-                  : step === "details"
-                  ? "70%"
-                  : step === "calendar"
-                  ? "85%"
-                  : "100%",
-            }}
-          />
+        <div className="space-y-4">
+          <StepIndicator current={currentStepNumber} />
+          <p className="text-center text-sm">Step {currentStepNumber} of 5</p>
+          {stepTitle && <h2 className="text-xl font-semibold text-center">{stepTitle}</h2>}
         </div>
       )}
 
@@ -201,25 +209,45 @@ export default function Home() {
         </div>
       )}
 
-      {step === "attendees" && <AttendeeForm onSubmit={handleAttendeeSubmit} />}
+      {step === "attendees" && (
+        <AttendeeForm onSubmit={handleAttendeeSubmit} onBack={() => setStep("service")} />
+      )}
 
-      {step === "meeting-type" && <MeetingTypeForm onSubmit={handleMeetingType} />}
+      {step === "meeting-type" && (
+        <MeetingTypeForm onSubmit={handleMeetingType} onBack={() => setStep("attendees")} />
+      )}
 
-      {step === "location" && <LocationForm onSubmit={handleLocationSubmit} />}
+      {step === "location" && (
+        <LocationForm onSubmit={handleLocationSubmit} onBack={() => setStep("meeting-type")} />
+      )}
 
       {step === "online-info" && (
         <div className="surface max-w-md mx-auto space-y-4">
           <p>If approved, the meeting will be hosted on my Zoom and might be recorded for record purposes.</p>
-          <button className="btn-accent w-full" onClick={() => setStep("details")}>
-            Continue
-          </button>
+          <div className="flex justify-between gap-2">
+            <button className="slot-btn flex-1" onClick={() => setStep("meeting-type")}>Back</button>
+            <button className="btn-accent flex-1" onClick={() => setStep("details")}>Continue</button>
+          </div>
         </div>
       )}
 
-      {step === "details" && selectedService && <UserDetailsForm service={selectedService.name} onSubmit={handleDetailsSubmit} />}
+      {step === "details" && selectedService && (
+        <UserDetailsForm
+          service={selectedService.name}
+          onSubmit={handleDetailsSubmit}
+          onBack={() =>
+            setStep(meetingInfo.meetingType === "Physical" ? "location" : "online-info")
+          }
+        />
+      )}
 
       {step === "calendar" && selectedService && (
-        <Calendar service={selectedService.name} duration={selectedService.duration} onBook={handleBooking} />
+        <Calendar
+          service={selectedService.name}
+          duration={selectedService.duration}
+          onBook={handleBooking}
+          onBack={() => setStep("details")}
+        />
       )}
 
       {step === "confirmed" && selectedService && (

--- a/src/components/AttendeeForm.tsx
+++ b/src/components/AttendeeForm.tsx
@@ -2,39 +2,37 @@ import { useState } from "react";
 
 interface Props {
   onSubmit: (size: string) => void;
+  onBack: () => void;
 }
 
-export function AttendeeForm({ onSubmit }: Props) {
-  const [size, setSize] = useState("");
+export function AttendeeForm({ onSubmit, onBack }: Props) {
+  const [size, setSize] = useState(1);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!size) return;
-    onSubmit(size);
+    onSubmit(String(size));
   };
 
   return (
-    <form onSubmit={handleSubmit} className="surface max-w-md mx-auto space-y-4">
-      <label className="block">
-        <span className="block mb-2 font-medium">Size of Attendees</span>
-        <select
+    <form onSubmit={handleSubmit} className="surface max-w-md mx-auto space-y-6 text-center">
+      <div className="flex items-center justify-center gap-2">
+        <input
+          type="number"
+          min={1}
           value={size}
-          onChange={(e) => setSize(e.target.value)}
-          required
-          className="input-field"
-        >
-          <option value="" disabled>
-            Choose...
-          </option>
-          <option>Just Me</option>
-          <option>2 - 5 People</option>
-          <option>6 - 25 People</option>
-          <option>26+ People</option>
-        </select>
-      </label>
-      <button type="submit" className="btn-accent w-full">
-        Next
-      </button>
+          onChange={(e) => setSize(parseInt(e.target.value) || 1)}
+          className="input-field w-24 text-center"
+        />
+        <span className="text-sm">people</span>
+      </div>
+      <div className="flex justify-between gap-2">
+        <button type="button" onClick={onBack} className="slot-btn flex-1">
+          Back
+        </button>
+        <button type="submit" className="btn-accent flex-1">
+          Next
+        </button>
+      </div>
     </form>
   );
 }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -7,10 +7,12 @@ export const Calendar = ({
   service,
   duration,
   onBook,
+  onBack,
 }: {
   service: string;
   duration: number;
   onBook: (bookingDetails: { date: string; time: string }) => void;
+  onBack: () => void;
 }) => {
   const today = new Date();
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -78,7 +80,10 @@ export const Calendar = ({
 
   return (
     <div className="w-full max-w-lg mx-auto space-y-6 animate-fade-in">
-      <h2 className="text-2xl font-bold text-center">Select a date and time for {service}</h2>
+      <div className="flex items-center justify-between">
+        <button onClick={onBack} className="slot-btn">Back</button>
+        <h2 className="text-2xl font-bold text-center flex-1">Select a date and time for {service}</h2>
+      </div>
       {isLoading ? (
         <p className="text-center">Loading availability...</p>
       ) : (

--- a/src/components/LocationForm.tsx
+++ b/src/components/LocationForm.tsx
@@ -7,9 +7,10 @@ interface Props {
     district: string;
     country: string;
   }) => void;
+  onBack: () => void;
 }
 
-export function LocationForm({ onSubmit }: Props) {
+export function LocationForm({ onSubmit, onBack }: Props) {
   const [choice, setChoice] = useState<"office" | "other" | "">("");
   const [address, setAddress] = useState("");
   const [district, setDistrict] = useState("");
@@ -88,9 +89,14 @@ export function LocationForm({ onSubmit }: Props) {
           />
         </div>
       )}
-      <button type="submit" className="btn-accent w-full">
-        Next
-      </button>
+      <div className="flex justify-between gap-2">
+        <button type="button" onClick={onBack} className="slot-btn flex-1">
+          Back
+        </button>
+        <button type="submit" className="btn-accent flex-1">
+          Next
+        </button>
+      </div>
     </form>
   );
 }

--- a/src/components/MeetingTypeForm.tsx
+++ b/src/components/MeetingTypeForm.tsx
@@ -1,25 +1,40 @@
+import { Monitor, MapPin } from "lucide-react";
+
 interface Props {
   onSubmit: (type: "Physical" | "Online") => void;
+  onBack: () => void;
 }
 
-export function MeetingTypeForm({ onSubmit }: Props) {
+export function MeetingTypeForm({ onSubmit, onBack }: Props) {
   return (
-    <div className="surface max-w-md mx-auto space-y-4">
-      <p className="font-medium">Do you prefer a physical or online meeting?</p>
-      <div className="flex flex-col gap-2">
-        <button
-          type="button"
-          onClick={() => onSubmit("Physical")}
-          className="slot-btn"
-        >
-          Physical
-        </button>
+    <div className="surface max-w-md mx-auto space-y-6">
+      <div className="flex flex-col gap-3">
         <button
           type="button"
           onClick={() => onSubmit("Online")}
-          className="slot-btn"
+          className="slot-btn flex items-center gap-3 text-left"
         >
-          Online
+          <Monitor className="w-5 h-5" />
+          <div>
+            <p className="font-medium">Online Meeting</p>
+            <p className="text-xs text-gray-500">Video call via Zoom/Teams</p>
+          </div>
+        </button>
+        <button
+          type="button"
+          onClick={() => onSubmit("Physical")}
+          className="slot-btn flex items-center gap-3 text-left"
+        >
+          <MapPin className="w-5 h-5" />
+          <div>
+            <p className="font-medium">In-Person Meeting</p>
+            <p className="text-xs text-gray-500">Physical location</p>
+          </div>
+        </button>
+      </div>
+      <div className="flex justify-between gap-2">
+        <button onClick={onBack} type="button" className="slot-btn flex-1">
+          Back
         </button>
       </div>
     </div>

--- a/src/components/StepIndicator.tsx
+++ b/src/components/StepIndicator.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+interface Props {
+  current: number;
+}
+
+export function StepIndicator({ current }: Props) {
+  const steps = [1, 2, 3, 4, 5];
+  return (
+    <div className="flex items-center justify-center">
+      {steps.map((step, index) => (
+        <React.Fragment key={step}>
+          {index > 0 && (
+            <div
+              className={`w-8 h-0.5 mx-2 ${current >= step ? "bg-brand-pink" : "bg-[var(--surface-border)]"}`}
+            />
+          )}
+          <div
+            className={`flex items-center justify-center w-9 h-9 rounded-full border text-sm font-medium ${
+              current >= step
+                ? "bg-brand-pink text-white border-brand-pink"
+                : "bg-[var(--surface)] border-[var(--surface-border)]"
+            }`}
+          >
+            {step}
+          </div>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/UserDetailsForm.tsx
+++ b/src/components/UserDetailsForm.tsx
@@ -6,10 +6,12 @@ import { User, Phone, Mail } from "lucide-react";
 export const UserDetailsForm = ({
   service,
   onSubmit,
-  }: {
-    service: string;
-    onSubmit: (details: { name: string; phone: string; email: string; note: string; reminder: boolean }) => void;
-  }) => {
+  onBack,
+}: {
+  service: string;
+  onSubmit: (details: { name: string; phone: string; email: string; note: string; reminder: boolean }) => void;
+  onBack: () => void;
+}) => {
     const [name, setName] = useState("");
     const [phone, setPhone] = useState("");
     const [email, setEmail] = useState("");
@@ -100,9 +102,14 @@ export const UserDetailsForm = ({
                 Send me a reminder 24 hours before
               </label>
             </div>
-            <button type="submit" className="w-full mt-2 btn-accent">
-              Next
-            </button>
+            <div className="flex justify-between gap-2 mt-2">
+              <button type="button" onClick={onBack} className="slot-btn flex-1">
+                Back
+              </button>
+              <button type="submit" className="btn-accent flex-1">
+                Next
+              </button>
+            </div>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- create visual step indicator for the five-step booking flow
- add back navigation and improved forms for attendees, meeting type, location, details, and calendar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c5d7fe208333a4c3e019b02abd48