### PR TITLE
refine booking flow styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,17 +5,19 @@
 :root {
   --accent: #FF69B4;
   --accent-foreground: #ffffff;
-  --background: #f3f3f3;
+  /* Neutral page background */
+  --background: #f5f7fa;
   --foreground: #1f1f1f;
-  --surface: rgba(255, 255, 255, 0.75);
-  --surface-border: rgba(0, 0, 0, 0.1);
+  /* Card surface styles */
+  --surface: #ffffff;
+  --surface-border: #e2e8f0;
 }
 
 .dark {
   --background: #1a1a1a;
   --foreground: #f3f3f3;
-  --surface: rgba(26, 26, 26, 0.65);
-  --surface-border: rgba(255, 255, 255, 0.08);
+  --surface: #2d2d2d;
+  --surface-border: rgba(255, 255, 255, 0.1);
 }
 
 @layer base {
@@ -38,14 +40,13 @@
     border-radius: 1rem;
     border: 1px solid var(--surface-border);
     background: var(--surface);
-    backdrop-filter: blur(20px) saturate(180%);
-    box-shadow: 0 4px 16px rgba(0,0,0,0.08);
-    padding: 1.25rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    padding: 1.5rem;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
   .surface:hover {
     border-color: var(--accent);
-    box-shadow: 0 6px 20px rgba(0,0,0,0.12);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
   }
 
   .btn-accent {
@@ -94,6 +95,21 @@
     background: var(--accent);
     border-color: var(--accent);
     color: var(--accent-foreground);
+  }
+
+  .option-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--surface-border);
+    background: var(--surface);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  .option-card:hover {
+    border-color: var(--accent);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   }
 
   .input-field {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -195,14 +195,11 @@ export default function Home() {
             <button
               key={service.name}
               onClick={() => handleServiceSelect(service)}
-              className={`flex flex-col items-start gap-3 text-left p-4 rounded-lg border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink transition-colors $
-{theme === "dark" ? "bg-white text-black border-gray-300 hover:bg-gray-100" : "bg-gray-800 text-white border-gray-700 hover:bg-gray-700"}`}
+              className="option-card text-left"
             >
-              <div className="flex items-center gap-2">
-                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-pink text-white text-xs font-bold">
-                  {idx + 1}
-                </span>
-              </div>
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-pink text-white text-xs font-bold">
+                {idx + 1}
+              </span>
               <span className="text-sm font-medium">{service.name}</span>
             </button>
           ))}

--- a/src/components/MeetingTypeForm.tsx
+++ b/src/components/MeetingTypeForm.tsx
@@ -12,7 +12,7 @@ export function MeetingTypeForm({ onSubmit, onBack }: Props) {
         <button
           type="button"
           onClick={() => onSubmit("Online")}
-          className="slot-btn flex items-center gap-3 text-left"
+          className="option-card w-full text-left"
         >
           <Monitor className="w-5 h-5" />
           <div>
@@ -23,7 +23,7 @@ export function MeetingTypeForm({ onSubmit, onBack }: Props) {
         <button
           type="button"
           onClick={() => onSubmit("Physical")}
-          className="slot-btn flex items-center gap-3 text-left"
+          className="option-card w-full text-left"
         >
           <MapPin className="w-5 h-5" />
           <div>


### PR DESCRIPTION
## Summary
- tweak global surface and option-card styles to better match reference UI
- apply new option-card styling to service and meeting type selections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2d5bbd7f8833393100b09828d457e